### PR TITLE
Fix ENV_DATA register write

### DIFF
--- a/components/ccs811/ccs811.c
+++ b/components/ccs811/ccs811.c
@@ -344,8 +344,8 @@ bool ccs811_set_environmental_data (ccs811_sensor_t* dev,
     uint16_t hum  = humidity * 512;
 
     // fill environmental data
-    uint8_t data[4]  = { temp >> 8, temp & 0xff,
-                         hum  >> 8, hum  & 0xff  };
+    uint8_t data[4]  = { hum  >> 8, hum  & 0xff,
+                         temp >> 8, temp & 0xff };
 
     // send environmental data to the sensor
     if (!ccs811_reg_write(dev, CCS811_REG_ENV_DATA, data, 4))


### PR DESCRIPTION
According to the CCS811 datasheet the ENV_DATA register format is humidity
on bytes 0 & 1 and temperature on bytes 2 & 3.